### PR TITLE
feat: add callouts for chat formatting

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,20 +18,24 @@ export const DEFAULT_SETTINGS: CAOSettings = {
 	chatFolderPath: "CAO/history",
 	streamingResponse: true,
 	showStats: true,
+	useCallouts: false,
 	customPrompts: [
 		{
 			name: "Summarize",
-			template: "Please provide a comprehensive summary of the following content. Include the main points, key takeaways, and important details:\n\n{cursor}"
+			template:
+				"Please provide a comprehensive summary of the following content. Include the main points, key takeaways, and important details:\n\n{cursor}",
 		},
 		{
 			name: "Rewrite",
-			template: "Please rewrite the following text to improve clarity, readability, and flow while maintaining the original meaning and tone:\n\n{cursor}"
+			template:
+				"Please rewrite the following text to improve clarity, readability, and flow while maintaining the original meaning and tone:\n\n{cursor}",
 		},
 		{
 			name: "Explain like I'm 5",
-			template: "Please explain {cursor} in simple terms that a 5-year-old could understand. Use everyday examples and avoid complex terminology."
-		}
-	]
+			template:
+				"Please explain {cursor} in simple terms that a 5-year-old could understand. Use everyday examples and avoid complex terminology.",
+		},
+	],
 };
 
 export class CAOSettingTab extends PluginSettingTab {
@@ -66,21 +70,17 @@ export class CAOSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName("API Provider")
-			.setDesc(
-				"Choose between Anthropic (official) or OpenAI-compatible APIs",
-			)
+			.setDesc("Choose between Anthropic (official) or OpenAI-compatible APIs")
 			.addDropdown((dropdown) =>
 				dropdown
 					.addOption("anthropic", "Anthropic (Official)")
 					.addOption("openai-compatible", "OpenAI Compatible")
 					.setValue(this.plugin.settings.provider)
-					.onChange(
-						async (value: "anthropic" | "openai-compatible") => {
-							this.plugin.settings.provider = value;
-							await this.plugin.saveSettings();
-							this.display(); // Refresh UI to show/hide fields
-						},
-					),
+					.onChange(async (value: "anthropic" | "openai-compatible") => {
+						this.plugin.settings.provider = value;
+						await this.plugin.saveSettings();
+						this.display(); // Refresh UI to show/hide fields
+					}),
 			);
 
 		// API Key field - dynamic based on provider
@@ -135,38 +135,14 @@ export class CAOSettingTab extends PluginSettingTab {
 				.setDesc("Claude model to use")
 				.addDropdown((dropdown) =>
 					dropdown
-						.addOption(
-							"claude-sonnet-4-5",
-							"Claude 4.5 Sonnet (latest)",
-						)
-						.addOption(
-							"claude-sonnet-4-0",
-							"Claude 4.0 Sonnet (latest)",
-						)
-						.addOption(
-							"claude-3-7-sonnet-latest",
-							"Claude 3.7 Sonnet (latest)",
-						)
-						.addOption(
-							"claude-haiku-4-5",
-							"Claude 4.5 Haiku (latest)",
-						)
-						.addOption(
-							"claude-3-5-haiku-latest",
-							"Claude 3.5 Haiku (latest)",
-						)
-						.addOption(
-							"claude-3-haiku-latest",
-							"Claude 3 Haiku (latest)",
-						)
-						.addOption(
-							"claude-opus-4-1",
-							"Claude 4.1 Opus (latest)",
-						)
-						.addOption(
-							"claude-opus-4-0",
-							"Claude 4.0 Opus (latest)",
-						)
+						.addOption("claude-sonnet-4-5", "Claude 4.5 Sonnet (latest)")
+						.addOption("claude-sonnet-4-0", "Claude 4.0 Sonnet (latest)")
+						.addOption("claude-3-7-sonnet-latest", "Claude 3.7 Sonnet (latest)")
+						.addOption("claude-haiku-4-5", "Claude 4.5 Haiku (latest)")
+						.addOption("claude-3-5-haiku-latest", "Claude 3.5 Haiku (latest)")
+						.addOption("claude-3-haiku-latest", "Claude 3 Haiku (latest)")
+						.addOption("claude-opus-4-1", "Claude 4.1 Opus (latest)")
+						.addOption("claude-opus-4-0", "Claude 4.0 Opus (latest)")
 						.setValue(this.plugin.settings.anthropicModel)
 						.onChange(async (value) => {
 							this.plugin.settings.anthropicModel = value;
@@ -199,16 +175,13 @@ export class CAOSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						const numValue = Number(value);
 						if (!numValue) {
-							this.plugin.settings.maxTokens =
-								DEFAULT_SETTINGS.maxTokens;
+							this.plugin.settings.maxTokens = DEFAULT_SETTINGS.maxTokens;
 							await this.plugin.saveSettings();
 						} else if (!isNaN(numValue) && numValue > 0) {
 							this.plugin.settings.maxTokens = numValue;
 							await this.plugin.saveSettings();
 						} else {
-							new Notice(
-								"Max tokens should be a positive integer.",
-							);
+							new Notice("Max tokens should be a positive integer.");
 						}
 					}),
 			);
@@ -224,20 +197,13 @@ export class CAOSettingTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						const numValue = Number(value);
 						if (!numValue) {
-							this.plugin.settings.temperature =
-								DEFAULT_SETTINGS.temperature;
+							this.plugin.settings.temperature = DEFAULT_SETTINGS.temperature;
 							await this.plugin.saveSettings();
-						} else if (
-							!isNaN(numValue) &&
-							numValue >= 0 &&
-							numValue <= 1
-						) {
+						} else if (!isNaN(numValue) && numValue >= 0 && numValue <= 1) {
 							this.plugin.settings.temperature = numValue;
 							await this.plugin.saveSettings();
 						} else {
-							new Notice(
-								"Temperature should be a number between 0 and 1.",
-							);
+							new Notice("Temperature should be a number between 0 and 1.");
 						}
 					}),
 			);
@@ -275,17 +241,27 @@ export class CAOSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					}),
 			);
+		new Setting(containerEl)
+			.setName("Callouts for chat formatting (Experimental)")
+			.setDesc("Use callouts instead of headers to format chat messages")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.useCallouts)
+					.onChange(async (value) => {
+						this.plugin.settings.useCallouts = value;
+						await this.plugin.saveSettings();
+					}),
+			);
 
 		// Custom Prompts Section
 		containerEl.createEl("h3", { text: "Custom Prompts" });
 		containerEl.createEl("p", {
-			text: "Create custom commands for quick prompt insertion. Use {cursor} to mark cursor position."
+			text: "Create custom commands for quick prompt insertion. Use {cursor} to mark cursor position.",
 		});
 
 		// Display existing templates
 		this.plugin.settings.customPrompts.forEach((template, index) => {
-			const setting = new Setting(containerEl)
-				.setName(template.name);
+			const setting = new Setting(containerEl).setName(template.name);
 
 			// Edit button
 			setting.addButton((button) =>
@@ -294,7 +270,7 @@ export class CAOSettingTab extends PluginSettingTab {
 					.setTooltip("Edit")
 					.onClick(() => {
 						this.showTemplateEditor(template, index);
-					})
+					}),
 			);
 
 			// Delete button
@@ -307,27 +283,26 @@ export class CAOSettingTab extends PluginSettingTab {
 						this.plugin.settings.customPrompts.splice(index, 1);
 						await this.plugin.saveSettings();
 						this.display(); // Refresh UI
-					})
+					}),
 			);
 		});
 
 		// Add new template button
-		new Setting(containerEl)
-			.addButton((button) =>
-				button
-					.setButtonText("Add Custom Prompt")
-					.setCta()
-					.onClick(() => {
-						this.showTemplateEditor();
-					})
-			);
+		new Setting(containerEl).addButton((button) =>
+			button
+				.setButtonText("Add Custom Prompt")
+				.setCta()
+				.onClick(() => {
+					this.showTemplateEditor();
+				}),
+		);
 	}
 
 	showTemplateEditor(template?: PromptTemplate, index?: number) {
 		const isEditing = template !== undefined;
 		const currentTemplate: PromptTemplate = template || {
 			name: "",
-			template: ""
+			template: "",
 		};
 
 		const modal = new TemplateEditorModal(
@@ -336,7 +311,7 @@ export class CAOSettingTab extends PluginSettingTab {
 			async (updatedTemplate) => {
 				// Validate name uniqueness and command conflicts
 				const existingIndex = this.plugin.settings.customPrompts.findIndex(
-					t => t.name === updatedTemplate.name
+					(t) => t.name === updatedTemplate.name,
 				);
 
 				if (!isEditing && existingIndex !== -1) {
@@ -351,9 +326,20 @@ export class CAOSettingTab extends PluginSettingTab {
 
 				// Check if command name conflicts with existing Obsidian commands
 				// Note: We check this.app.commands.commands which contains all registered commands
-				if ((this.app as any).commands?.commands && (this.app as any).commands.commands[updatedTemplate.name]) {
-					if (!isEditing || (isEditing && index !== undefined && this.plugin.settings.customPrompts[index].name !== updatedTemplate.name)) {
-						new Notice("A command with this name already exists. Please choose a different name.");
+				if (
+					(this.app as any).commands?.commands &&
+					(this.app as any).commands.commands[updatedTemplate.name]
+				) {
+					if (
+						!isEditing ||
+						(isEditing &&
+							index !== undefined &&
+							this.plugin.settings.customPrompts[index].name !==
+								updatedTemplate.name)
+					) {
+						new Notice(
+							"A command with this name already exists. Please choose a different name.",
+						);
 						return;
 					}
 				}
@@ -367,7 +353,7 @@ export class CAOSettingTab extends PluginSettingTab {
 
 				await this.plugin.saveSettings();
 				this.display(); // Refresh UI
-			}
+			},
 		);
 		modal.open();
 	}
@@ -377,7 +363,11 @@ class TemplateEditorModal extends Modal {
 	template: PromptTemplate;
 	onSave: (template: PromptTemplate) => void;
 
-	constructor(app: App, template: PromptTemplate, onSave: (template: PromptTemplate) => void) {
+	constructor(
+		app: App,
+		template: PromptTemplate,
+		onSave: (template: PromptTemplate) => void,
+	) {
 		super(app);
 		this.template = { ...template };
 		this.onSave = onSave;
@@ -397,11 +387,11 @@ class TemplateEditorModal extends Modal {
 		nameSection.createEl("h3", { text: "Command Name" });
 		nameSection.createEl("p", {
 			text: "Name for the command (e.g., 'explain' creates 'explain' command)",
-			cls: "setting-item-description"
+			cls: "setting-item-description",
 		});
 
 		const nameInput = nameSection.createEl("input", {
-			type: "text"
+			type: "text",
 		});
 		nameInput.value = this.template.name; // Set value after creation
 		nameInput.style.width = "100%";
@@ -419,11 +409,11 @@ class TemplateEditorModal extends Modal {
 		templateSection.createEl("h3", { text: "Template Content" });
 		templateSection.createEl("p", {
 			text: "Template content. Use {cursor} to mark where cursor should be placed after insertion.",
-			cls: "setting-item-description"
+			cls: "setting-item-description",
 		});
 
 		const templateTextArea = templateSection.createEl("textarea", {
-			placeholder: "Please explain {cursor} in simple terms for beginners"
+			placeholder: "Please explain {cursor} in simple terms for beginners",
 		});
 		templateTextArea.value = this.template.template; // Set value after creation
 		templateTextArea.style.width = "100%";
@@ -438,7 +428,9 @@ class TemplateEditorModal extends Modal {
 		});
 
 		// Buttons
-		const buttonContainer = contentEl.createEl("div", { cls: "modal-button-container" });
+		const buttonContainer = contentEl.createEl("div", {
+			cls: "modal-button-container",
+		});
 		buttonContainer.style.display = "flex";
 		buttonContainer.style.justifyContent = "flex-end";
 		buttonContainer.style.gap = "8px";

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface CAOSettings {
 	chatFolderPath: string;
 	streamingResponse: boolean;
 	showStats: boolean;
+	useCallouts: boolean;
 	customPrompts: PromptTemplate[];
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ async function resolveWikilink(
 ): Promise<string | null> {
 	// Remove display text if present (everything after the pipe)
 	linkText = linkText.split("|")[0];
-	
+
 	// Parse link components (file, heading, block)
 	let [fileName, subPath] = linkText.split("#");
 
@@ -53,10 +53,7 @@ async function resolveWikilink(
 			if (headingIndex !== -1) {
 				// Find next heading of same or higher level
 				const remainingContent = fileContent.slice(headingIndex);
-				const nextHeadingRegex = new RegExp(
-					`\\n#{1,${heading.level}}\\s`,
-					"g",
-				);
+				const nextHeadingRegex = new RegExp(`\\n#{1,${heading.level}}\\s`, "g");
 				nextHeadingRegex.lastIndex = 1; // Start search after current heading
 				const match = nextHeadingRegex.exec(remainingContent);
 				const endIndex = match
@@ -83,16 +80,16 @@ async function resolveWikilink(
 }
 
 async function parseUserPrompt(
-	app: App, 
-	userQuery: string, 
-	processedWikilinks: Set<string> = new Set()
+	app: App,
+	userQuery: string,
+	processedWikilinks: Set<string> = new Set(),
 ): Promise<string> {
 	let userPrompt = `User query: ${userQuery}`;
 	const wikilinks = extractWikilinks(userQuery);
 	for (const wikilink of wikilinks) {
 		// Skip if this wikilink has already been processed
 		if (processedWikilinks.has(wikilink)) continue;
-		
+
 		const resolvedContent = await resolveWikilink(app, wikilink);
 		if (resolvedContent) {
 			userPrompt += `\n\nContext from [[${wikilink}]]:\n${resolvedContent}`;
@@ -111,10 +108,12 @@ export async function parseChat(
 	const messages: ChatMessage[] = [];
 	let currentMessage: Partial<ChatMessage> | null = null;
 	let content: string[] = [];
+	let inCallout = false; // Track if we're inside a callout block
 	// Track which wikilinks have already been processed
 	const processedWikilinks = new Set<string>();
 
 	for (const line of lines) {
+		// Check for header format (legacy)
 		if (line.startsWith("### Me")) {
 			if (currentMessage) {
 				currentMessage.content = content.join("\n").trim();
@@ -122,15 +121,58 @@ export async function parseChat(
 			}
 			currentMessage = { role: "user", content: "" };
 			content = [];
+			inCallout = false;
 		} else if (line.startsWith("### CAO")) {
 			if (currentMessage) {
 				const userQuery = content.join("\n").trim();
-				// Modified to pass the set of processed wikilinks
-				currentMessage.content = await parseUserPrompt(app, userQuery, processedWikilinks);
+				currentMessage.content = await parseUserPrompt(
+					app,
+					userQuery,
+					processedWikilinks,
+				);
 				messages.push(currentMessage as ChatMessage);
 			}
 			currentMessage = { role: "assistant", content: "" };
 			content = [];
+			inCallout = false;
+		}
+		// Check for callout format
+		else if (line.startsWith("> [!question] Me") || line.startsWith("> [!question]+ Me")) {
+			if (currentMessage) {
+				let processedContent = content.join("\n").trim();
+				// Remove callout prefixes if we were in a callout
+				if (inCallout) {
+					processedContent = content
+						.map((l) => (l.startsWith("> ") ? l.slice(2) : l))
+						.join("\n")
+						.trim();
+				}
+				currentMessage.content = processedContent;
+				messages.push(currentMessage as ChatMessage);
+			}
+			currentMessage = { role: "user", content: "" };
+			content = [];
+			inCallout = true;
+		} else if (line.startsWith("> [!success] CAO") || line.startsWith("> [!success]+ CAO")) {
+			if (currentMessage) {
+				let processedContent = content.join("\n").trim();
+				// Remove callout prefixes if we were in a callout, then parse wikilinks
+				if (inCallout) {
+					processedContent = content
+						.map((l) => (l.startsWith("> ") ? l.slice(2) : l))
+						.join("\n")
+						.trim();
+				}
+				currentMessage.content = await parseUserPrompt(
+					app,
+					processedContent,
+					processedWikilinks,
+				);
+				messages.push(currentMessage as ChatMessage);
+			}
+			currentMessage = { role: "assistant", content: "" };
+			content = [];
+			inCallout = true;
 		} else {
 			content.push(line);
 		}
@@ -138,9 +180,19 @@ export async function parseChat(
 
 	// Add the last message
 	if (currentMessage) {
-		const userQuery = content.join("\n").trim();
-		// Modified to pass the set of processed wikilinks
-		currentMessage.content = await parseUserPrompt(app, userQuery, processedWikilinks);
+		let processedContent = content.join("\n").trim();
+		// Remove callout prefixes if we were in a callout, then parse wikilinks
+		if (inCallout) {
+			processedContent = content
+				.map((l) => (l.startsWith("> ") ? l.slice(2) : l))
+				.join("\n")
+				.trim();
+		}
+		currentMessage.content = await parseUserPrompt(
+			app,
+			processedContent,
+			processedWikilinks,
+		);
 		messages.push(currentMessage as ChatMessage);
 	}
 
@@ -151,6 +203,196 @@ export async function parseChat(
 	}
 
 	return messages;
+}
+
+// Format detection and validation utilities
+export interface ChatValidationResult {
+	isValid: boolean;
+	messages?: ChatMessage[];
+	format?: "headers" | "callouts" | "empty";
+	error?: {
+		type: "format" | "empty_message" | "parsing";
+		message: string;
+	};
+}
+
+export async function validateChatBeforeResponse(
+	app: App,
+	text: string,
+	useCallouts: boolean,
+): Promise<ChatValidationResult> {
+	// Step 1: Detect chat format
+	const detectedFormat = detectChatFormat(text);
+
+	// Step 2: Handle invalid formats
+	if (detectedFormat === "mixed") {
+		return {
+			isValid: false,
+			error: {
+				type: "format",
+				message:
+					"This chat contains mixed formatting (both headers and callouts).",
+			},
+		};
+	}
+
+	// Step 3: Handle empty format (invalid for conversations)
+	if (detectedFormat === "empty") {
+		return {
+			isValid: false,
+			error: {
+				type: "format",
+				message: "No valid formatting found (headers or callouts).",
+			},
+		};
+	}
+
+	// Step 4: Validate format consistency with settings
+	if (detectedFormat === "headers" && useCallouts) {
+		return {
+			isValid: false,
+			error: {
+				type: "format",
+				message:
+					'This chat uses header format, please disable "Use callouts for chat formatting" in settings to continue.',
+			},
+		};
+	}
+
+	if (detectedFormat === "callouts" && !useCallouts) {
+		return {
+			isValid: false,
+			error: {
+				type: "format",
+				message:
+					'This chat uses callout format, please enable "Use callouts for chat formatting" in settings to continue.',
+			},
+		};
+	}
+
+	// Step 5: Parse messages
+	const messages = await parseChat(app, text);
+	if (!messages || messages.length === 0) {
+		return {
+			isValid: false,
+			error: {
+				type: "parsing",
+				message:
+					"Invalid chat format, messages should alternate user query and assistant response.",
+			},
+		};
+	}
+
+	// Step 6: Check if all messages are empty
+	// FIXME: need to slice for the prefix added in parseUserPrompt()
+	const allMessagesEmpty = messages.every(
+		(msg) => !msg.content.slice(12).trim(),
+	);
+	if (allMessagesEmpty) {
+		return {
+			isValid: false,
+			error: {
+				type: "empty_message",
+				message: "Query message is empty.",
+			},
+		};
+	}
+
+	// Step 7: All validation passed
+	return {
+		isValid: true,
+		messages,
+		format: detectedFormat,
+	};
+}
+
+export function detectChatFormat(
+	text: string,
+): "headers" | "callouts" | "mixed" | "empty" {
+	const lines = text.split("\n");
+
+	let hasHeaders = false;
+	let hasCallouts = false;
+
+	for (const line of lines) {
+		if (line.startsWith("### Me") || line.startsWith("### CAO")) {
+			hasHeaders = true;
+		} else if (
+			line.startsWith("> [!question] Me") ||
+			line.startsWith("> [!question]+ Me") ||
+			line.startsWith("> [!success] CAO") ||
+			line.startsWith("> [!success]+ CAO")
+		) {
+			hasCallouts = true;
+		}
+
+		// Early exit if both formats detected
+		if (hasHeaders && hasCallouts) {
+			return "mixed";
+		}
+	}
+
+	if (hasHeaders) {
+		return "headers";
+	} else if (hasCallouts) {
+		return "callouts";
+	} else {
+		return "empty";
+	}
+}
+
+// Helper functions for callout formatting
+export function formatNewUserSection(
+	useCallouts: boolean,
+	forNewFile: boolean = false,
+): string {
+	const prefix = forNewFile ? "" : "\n\n";
+	if (useCallouts) {
+		return prefix + "> [!question]+ Me\n> ";
+	} else {
+		return prefix + "### Me\n";
+	}
+}
+
+export function formatNewAISection(useCallouts: boolean): string {
+	if (useCallouts) {
+		return "\n\n> [!success]+ CAO\n";
+	} else {
+		return "\n\n### CAO\n";
+	}
+}
+
+// Process content for callout format by adding "> " prefix to all lines
+export function processCalloutContent(text: string): string {
+	return text
+		.split("\n")
+		.map((line) => (line.trim() === "" ? ">" : `> ${line}`))
+		.join("\n");
+}
+
+// Process streaming chunks for callout format
+export function processStreamingCalloutContent(
+	chunk: string,
+	isStartOfLine: boolean,
+): { processedChunk: string; newIsStartOfLine: boolean } {
+	if (!chunk) return { processedChunk: chunk, newIsStartOfLine: isStartOfLine };
+
+	let processedChunk = "";
+	let newIsStartOfLine = isStartOfLine;
+
+	for (let i = 0; i < chunk.length; i++) {
+		const char = chunk[i];
+
+		if (newIsStartOfLine) {
+			processedChunk += "> ";
+		}
+
+		processedChunk += char;
+
+		newIsStartOfLine = char === "\n";
+	}
+
+	return { processedChunk, newIsStartOfLine };
 }
 
 export function sleep(ms: number): Promise<void> {
@@ -180,18 +422,28 @@ export async function streamText(
 }
 
 // Template processing utilities
-export function validateTemplateName(name: string): { valid: boolean; error?: string } {
+export function validateTemplateName(name: string): {
+	valid: boolean;
+	error?: string;
+} {
 	if (!name.trim()) {
 		return { valid: false, error: "Template name cannot be empty" };
 	}
 
 	// Allow alphanumeric characters, spaces, hyphens, and apostrophes
 	if (!/^[a-zA-Z0-9\s\-']+$/.test(name)) {
-		return { valid: false, error: "Template name can only contain letters, numbers, spaces, hyphens, and apostrophes" };
+		return {
+			valid: false,
+			error:
+				"Template name can only contain letters, numbers, spaces, hyphens, and apostrophes",
+		};
 	}
 
 	if (name.length > 20) {
-		return { valid: false, error: "Template name must be 20 characters or less" };
+		return {
+			valid: false,
+			error: "Template name must be 20 characters or less",
+		};
 	}
 
 	return { valid: true };
@@ -210,7 +462,7 @@ export function processTemplateContent(template: string): {
 
 	// Calculate cursor position
 	const beforeCursor = template.substring(0, cursorIndex);
-	const lines = beforeCursor.split('\n');
+	const lines = beforeCursor.split("\n");
 	const line = lines.length - 1;
 	const ch = lines[lines.length - 1].length;
 
@@ -219,7 +471,7 @@ export function processTemplateContent(template: string): {
 
 	return {
 		processedContent,
-		cursorPosition: { line, ch }
+		cursorPosition: { line, ch },
 	};
 }
 
@@ -241,13 +493,17 @@ export function sanitizeTemplateName(input: string): string {
 
 // Chat file discovery utilities
 export function getChatFiles(app: App, chatFolderPath: string) {
-	return app.vault.getMarkdownFiles().filter(file =>
-		file.path.startsWith(chatFolderPath + "/") &&
-		file.extension === "md"
-	);
+	return app.vault
+		.getMarkdownFiles()
+		.filter(
+			(file) =>
+				file.path.startsWith(chatFolderPath + "/") && file.extension === "md",
+		);
 }
 
-export function sortFilesByMtime<T extends { stat: { mtime: number } }>(files: T[]): T[] {
+export function sortFilesByMtime<T extends { stat: { mtime: number } }>(
+	files: T[],
+): T[] {
 	return files.sort((a, b) => b.stat.mtime - a.stat.mtime);
 }
 


### PR DESCRIPTION
Add experimental callouts feature as alternative to header formatting.

- Toggle setting to switch between headers (`### Me/CAO`) and callouts (`> [!question]+ Me/CAO`) 
- Maintains backward compatibility with existing chats
- Prevents format mixing within conversations
- Supports both streaming and non-streaming responses

Resolves #12